### PR TITLE
Upgrade mocha from 2 to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AMD module tracing for build processes.",
   "main": "trace.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha test"
+    "test": "mocha test"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,6 @@
     "esprima": "^4.0.0"
   },
   "devDependencies": {
-    "mocha": "^2.2.1"
+    "mocha": "^4.0.1"
   }
 }


### PR DESCRIPTION
Maybe not so important, but let's use the most recent maintained version.

Additonially: Call mocha without the path to node_modules/.bin. NPM searches this path
automatically, when "npm test" or "nom run *" is executed.