### PR TITLE
Introduce the public module `parse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,10 +517,58 @@ var config = require('amodro-config')
 
 Arguments to `modify`:
 
-* **contents**: String. File conents that may contain a config call.
+* **contents**: String. File contents that may contain a config call.
 * **onConfig**: Function. Function called when the first config call is found. It will be passed an Object which is the current config, and the onConfig function should return an Object to use as the new config that will be serialized into the contents, replacing the old config.
 
 Returns a String the contents with the config changes applied.
+
+### amodro-trace/parse
+
+This module helps to extract dependencies from a JS file, which is an AMD module - which is wrapped in a `require` or a `define` statemenet. The API methods on this module:
+
+#### parse.parse
+
+Parses the input JavaScript text and returns an AST of it. Expects a JavaScript content. The returned object can be used later in other calls, or to other module analysis.
+
+```javascript
+var astRoot = require('amodro-trace/parse').parse(contents, options);
+```
+
+Aruguments to `parse`:
+
+* **contents**: String. File contents of an AMD module.
+* **options**: Object. Optional. Options for the `esprima` parser: Only `range` and `loc` properties are recognized.
+
+Returns an Object with the JavaScript AST build from the module contents.
+
+#### parse.traverse
+
+Walks the AST from the specified (root) node up to its leaves and calls the specified callback function with two arguments - the visited node and its parent node.
+
+```javascript
+require('amodro-trace/parse').traverse(rootNode, function (node, parent) {
+  ...
+});
+```
+
+Aruguments to `traverse`:
+
+* **node**: Object. AST root node to start traversing with. Produced by the `parse` method.
+* **visitor**: Function. Callback receiving nodes with its parents.
+
+#### parse.findDependencies
+
+Finds all dependencies specified in the AMD module dependency array, or inside simplified CommonJS wrappers inside the module factory function. Expects a JavaScript AMD module wrapped in a `requirejs/require/define` call. The returned list of dependent modules and their formal parameters match in the correct code.
+
+```javascript
+var dependencies = require('amodro-trace/parse').findDependencies(contents);
+```
+
+Aruguments to `findDependencies`:
+
+* **contents**: String or Object. File contents of an AMD module, or an AST root produced by the `parse` method.
+
+Returns an object with two properties. The property "modules" is an array of dependent module paths as strings. The dependencies have not been normalized; they may be relative IDs. The property "params" is an array of formal parameter names as strings.
 
 ## Read transforms
 

--- a/README.md
+++ b/README.md
@@ -524,7 +524,20 @@ Returns a String the contents with the config changes applied.
 
 ### amodro-trace/parse
 
-This module helps to extract dependencies from a JS file, which is an AMD module - which is wrapped in a `require` or a `define` statemenet. The API methods on this module:
+This module helps to extract dependencies from a JS file, which is an AMD module - which is wrapped in a `require` or a `define` statement.
+
+Methods accept either a string with the source content or an object  with JavaScript AST. If you traverse the AST multiple times, you can improve performance by parsing the source just once by a parser producing output according to the [ESTree Spec](https://github.com/estree/estree). For example, [Esprima](https://github.com/jquery/esprima):
+
+```javascript
+var esprima = require('esprima');
+
+var astRoot = esprima.parse(fileContents, {
+  range: includeIndexBasedRangeLocation,
+  loc: includeLineAndColumnBasedLocation
+});
+```
+
+The API methods on this module:
 
 #### parse.parse
 
@@ -534,7 +547,7 @@ Parses the input JavaScript text and returns an AST of it. Expects a JavaScript 
 var astRoot = require('amodro-trace/parse').parse(contents, options);
 ```
 
-Aruguments to `parse`:
+Arguments to `parse`:
 
 * **contents**: String. File contents of an AMD module.
 * **options**: Object. Optional. Options for the `esprima` parser: Only `range` and `loc` properties are recognized.
@@ -551,7 +564,7 @@ require('amodro-trace/parse').traverse(rootNode, function (node, parent) {
 });
 ```
 
-Aruguments to `traverse`:
+Arguments to `traverse`:
 
 * **node**: Object. AST root node to start traversing with. Produced by the `parse` method.
 * **visitor**: Function. Callback receiving nodes with its parents.
@@ -564,7 +577,7 @@ Finds all dependencies specified in the AMD module dependency array, or inside s
 var dependencies = require('amodro-trace/parse').findDependencies(contents);
 ```
 
-Aruguments to `findDependencies`:
+Arguments to `findDependencies`:
 
 * **contents**: String or Object. File contents of an AMD module, or an AST root produced by the `parse` method.
 
@@ -578,7 +591,7 @@ Finds only CommonJS dependencies, ones that are the form  `require('stringLitera
 var dependencies = require('amodro-trace/parse').findCjsDependencies(contents);
 ```
 
-Aruguments to `findCjsDependencies`:
+Arguments to `findCjsDependencies`:
 
 * **contents**: String or Object. File contents of a CommonJS module, or an AST root produced by the `parse` method.
 

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ Returns an Object with the JavaScript AST build from the module contents.
 
 #### parse.traverse
 
-Walks the AST from the specified (root) node up to its leaves and calls the specified callback function with two arguments - the visited node and its parent node.
+Walks the AST from the specified (root) node up to its leaves and calls the specified callback function with two arguments - the visited node and its parent node. Once the callback returns `false`, traversing stops.
 
 ```javascript
 require('amodro-trace/parse').traverse(rootNode, function (node, parent) {
@@ -564,7 +564,22 @@ require('amodro-trace/parse').traverse(rootNode, function (node, parent) {
 });
 ```
 
-Arguments to `traverse`:
+Arguments to `traverseBroad`:
+
+* **node**: Object. AST root node to start traversing with. Produced by the `parse` method.
+* **visitor**: Function. Callback receiving nodes with its parents.
+
+#### parse.traverseBroad
+
+Walks the AST from the specified (root) node up to its leaves and calls the specified callback function with two arguments - the visited node and its parent node. Once the callback returns `false`, its children will be skipped and the traversing will continue with its next sibling.
+
+```javascript
+require('amodro-trace/parse').traverseBroad(rootNode, function (node, parent) {
+  ...
+});
+```
+
+Arguments to `traverseBroad`:
 
 * **node**: Object. AST root node to start traversing with. Produced by the `parse` method.
 * **visitor**: Function. Callback receiving nodes with its parents.

--- a/README.md
+++ b/README.md
@@ -570,6 +570,20 @@ Aruguments to `findDependencies`:
 
 Returns an object with two properties. The property "modules" is an array of dependent module paths as strings. The dependencies have not been normalized; they may be relative IDs. The property "params" is an array of formal parameter names as strings.
 
+#### parse.findCjsDependencies
+
+Finds only CommonJS dependencies, ones that are the form  `require('stringLiteral')`. Expects a JavaScript module. The returned list of dependent modules and their formal parameters match in the correct code.
+
+```javascript
+var dependencies = require('amodro-trace/parse').findCjsDependencies(contents);
+```
+
+Aruguments to `findCjsDependencies`:
+
+* **contents**: String or Object. File contents of a CommonJS module, or an AST root produced by the `parse` method.
+
+Returns an object with two properties. The property "modules" is an array of dependent module paths as strings. The dependencies have not been normalized; they may be relative IDs. The property "params" is an array of formal parameter names as strings.
+
 ## Read transforms
 
 See the [readTransform](#readtransform) option for background on read transforms. This section describes read transforms provided by this project.

--- a/README.md
+++ b/README.md
@@ -530,11 +530,7 @@ Methods accept either a string with the source content or an object  with JavaSc
 
 ```javascript
 var esprima = require('esprima');
-
-var astRoot = esprima.parse(fileContents, {
-  range: includeIndexBasedRangeLocation,
-  loc: includeLineAndColumnBasedLocation
-});
+var astRoot = esprima.parse(fileContents);
 ```
 
 The API methods on this module:

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -905,7 +905,7 @@ define(['esprima', './lang'], function (esprima, lang) {
      * Otherwise null.
      */
     parse.parseNode = function (node, onMatch, fnExpScope) {
-        var name, deps, cjsDeps, arg, factory, exp, refsDefine, bodyNode,
+        var name, deps, cjsDeps, arg, factoryIndex, factory, exp, refsDefine, bodyNode,
             args = node && node[argPropName],
             callName = parse.hasRequire(node),
             isUmd = false;
@@ -913,20 +913,32 @@ define(['esprima', './lang'], function (esprima, lang) {
         if (callName === 'require' || callName === 'requirejs') {
             //A plain require/requirejs call
             arg = node[argPropName] && node[argPropName][0];
-            if (arg && arg.type !== 'ArrayExpression') {
+            if (arg) {
                 if (arg.type === 'ObjectExpression') {
                     //A config call, try the second arg.
                     arg = node[argPropName][1];
+                    factoryIndex = 2;
+                } else {
+                    factoryIndex = 1;
                 }
-            }
-
-            deps = getValidDeps(arg);
-            if (!deps) {
-                return;
-            }
-            factory = node[argPropName][1];
-            if (isFnExpression(factory)) {
-                deps.params = getFormalParameters(factory);
+                if (arg.type === 'ArrayExpression') {
+                    deps = getValidDeps(arg);
+                    if (!deps) {
+                        return;
+                    }
+                    factory = node[argPropName][factoryIndex];
+                    if (isFnExpression(factory)) {
+                        deps.params = getFormalParameters(factory);
+                    }
+                } else if (isFnExpression(arg)) {
+                    //If no deps and a factory function, could be a commonjs sugar
+                    //wrapper, scan the function for dependencies.
+                    cjsDeps = parse.getAnonDepsFromNode(arg);
+                    if (!cjsDeps.length) {
+                        return;
+                    }
+                    deps = cjsDeps;
+                }
             }
 
             return onMatch("require", null, null, deps, node);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -207,21 +207,6 @@ define(['esprima', './lang'], function (esprima, lang) {
         return result || null;
     }
 
-    /**
-     * Just parses the text to an AST to be used in other methods.
-     * @param {String} fileName
-     * @param {String} fileContents
-     * @param {Object} options
-     * @returns {Object} AST
-     */
-    parse.parseFileContents = function (fileName, fileContents, options) {
-        var localOptions = options || {};
-        return esprima.parse(fileContents, {
-            range: localOptions.range,
-            loc: localOptions.loc
-        });
-    }
-
     parse.traverse = traverse;
     parse.traverseBroad = traverseBroad;
     parse.isFnExpression = isFnExpression;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -65,7 +65,7 @@ define(['esprima', './lang'], function (esprima, lang) {
             return false;
         }
         for (var i = 0, keys = Object.keys(object); i < keys.length; i++) {
-            child = object[key];
+            child = object[keys[i]];
             if (typeof child === 'object' && child !== null) {
                 traverseBroad(child, visitor, object);
             }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -624,24 +624,24 @@ define(['esprima', './lang'], function (esprima, lang) {
     /**
      * Finds only CJS dependencies, ones that are the form
      * require('stringLiteral')
+     * @param {String} fileName
+     * @param {String} fileContents (or astRoot)
+     * @param {Object} options
+     *
+     * @returns {Array} an array of dependency strings. The dependencies
+     * have not been normalized, they may be relative IDs. An additional
+     * array of Formal parameter names is available as the property "params"
+     * on the returned array.
      */
     parse.findCjsDependencies = function (fileName, fileContents) {
-        var dependencies = [];
+        var dependencies = [],
+            params = [],
+            astRoot = typeof fileContents === 'string' ?
+                      esprima.parse(fileContents) : fileContents;
 
-        traverse(esprima.parse(fileContents), function (node) {
-            var arg;
+        this.findRequireDepNames(astRoot, dependencies, params);
 
-            if (node && node.type === 'CallExpression' && node.callee &&
-                    node.callee.type === 'Identifier' &&
-                    node.callee.name === 'require' && node[argPropName] &&
-                    node[argPropName].length === 1) {
-                arg = node[argPropName][0];
-                if (arg.type === 'Literal') {
-                    dependencies.push(arg.value);
-                }
-            }
-        });
-
+        dependencies.params = params;
         return dependencies;
     };
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -908,12 +908,17 @@ define(['esprima', './lang'], function (esprima, lang) {
                 if (arg.type === 'ObjectExpression') {
                     //A config call, try the second arg.
                     arg = node[argPropName][1];
+                    //Guard against expressions like "require({})"
+                    if (!arg) {
+                        return;
+                    }
                     factoryIndex = 2;
                 } else {
                     factoryIndex = 1;
                 }
                 if (arg.type === 'ArrayExpression') {
                     deps = getValidDeps(arg);
+                    //Guard against expressions like "require([], function(){})"
                     if (!deps) {
                         return;
                     }
@@ -983,6 +988,10 @@ define(['esprima', './lang'], function (esprima, lang) {
 
             if (deps && deps.type === 'ArrayExpression') {
                 deps = getValidDeps(deps);
+                //Guard against expressions like "define([], function(){})"
+                if (!deps) {
+                    return;
+                }
                 if (isFnExpression(factory)) {
                     deps.params = getFormalParameters(factory);
                 }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -31,20 +31,20 @@ define(['esprima', './lang'], function (esprima, lang) {
         hasProp = lang.hasProp;
 
     //From an esprima example for traversing its ast.
-    function traverse(object, visitor) {
+    function traverse(object, visitor, parent) {
         var child;
 
         if (!object) {
             return;
         }
 
-        if (visitor.call(null, object) === false) {
+        if (visitor.call(null, object, parent) === false) {
             return false;
         }
         for (var i = 0, keys = Object.keys(object); i < keys.length; i++) {
             child = object[keys[i]];
             if (typeof child === 'object' && child !== null) {
-                if (traverse(child, visitor) === false) {
+                if (traverse(child, visitor, object) === false) {
                     return false;
                 }
             }
@@ -54,20 +54,20 @@ define(['esprima', './lang'], function (esprima, lang) {
     //Like traverse, but visitor returning false just
     //stops that subtree analysis, not the rest of tree
     //visiting.
-    function traverseBroad(object, visitor) {
+    function traverseBroad(object, visitor, parent) {
         var child;
 
         if (!object) {
             return;
         }
 
-        if (visitor.call(null, object) === false) {
+        if (visitor.call(null, object, parent) === false) {
             return false;
         }
         for (var i = 0, keys = Object.keys(object); i < keys.length; i++) {
             child = object[key];
             if (typeof child === 'object' && child !== null) {
-                traverseBroad(child, visitor);
+                traverseBroad(child, visitor, object);
             }
         }
     }
@@ -105,6 +105,16 @@ define(['esprima', './lang'], function (esprima, lang) {
         return (node && (node.type === 'FunctionExpression' ||
                              node.type === 'ArrowFunctionExpression'));
     }
+
+    // Returns an array of formal parameter names of the specified factory
+    // function.
+    function getFormalParameters(factory) {
+        return (factory && factory.params || []).filter(function (param) {
+            return param.type === 'Identifier';
+        }).map(function (param) {
+            return param.name;
+        });
+   }
 
     /**
      * Main parse function. Returns a string of any valid require or
@@ -195,6 +205,21 @@ define(['esprima', './lang'], function (esprima, lang) {
         }
 
         return result || null;
+    }
+
+    /**
+     * Just parses the text to an AST to be used in other methods.
+     * @param {String} fileName
+     * @param {String} fileContents
+     * @param {Object} options
+     * @returns {Object} AST
+     */
+    parse.parseFileContents = function (fileName, fileContents, options) {
+        var localOptions = options || {};
+        return esprima.parse(fileContents, {
+            range: localOptions.range,
+            loc: localOptions.loc
+        });
     }
 
     parse.traverse = traverse;
@@ -383,10 +408,11 @@ define(['esprima', './lang'], function (esprima, lang) {
      */
     parse.getAnonDepsFromNode = function (node) {
         var deps = [],
+            params = [],
             funcArgLength;
 
         if (node) {
-            this.findRequireDepNames(node, deps);
+            this.findRequireDepNames(node, deps, params);
 
             //If no deps, still add the standard CommonJS require, exports,
             //module, in that order, to the deps, but only if specified as
@@ -396,8 +422,10 @@ define(['esprima', './lang'], function (esprima, lang) {
             if (funcArgLength) {
                 deps = (funcArgLength > 1 ? ["require", "exports", "module"] :
                         ["require"]).concat(deps);
+                params = getFormalParameters(node).concat(params);
             }
         }
+        deps.params = params;
         return deps;
     };
 
@@ -566,21 +594,30 @@ define(['esprima', './lang'], function (esprima, lang) {
      * Finds all dependencies specified in dependency arrays and inside
      * simplified commonjs wrappers.
      * @param {String} fileName
-     * @param {String} fileContents
+     * @param {String} fileContents (or astRoot)
+     * @param {Object} options
      *
      * @returns {Array} an array of dependency strings. The dependencies
-     * have not been normalized, they may be relative IDs.
+     * have not been normalized, they may be relative IDs. An additional
+     * array of Formal parameter names is available as the property "params"
+     * on the returned array.
      */
     parse.findDependencies = function (fileName, fileContents, options) {
         var dependencies = [],
-            astRoot = esprima.parse(fileContents);
+            params = [],
+            astRoot = typeof fileContents === 'string' ?
+                      esprima.parse(fileContents) : fileContents;
 
         parse.recurse(astRoot, function (callName, config, name, deps) {
             if (deps) {
                 dependencies = dependencies.concat(deps);
+                if (deps.params) {
+                    params = params.concat(deps.params);
+                }
             }
         }, options);
 
+        dependencies.params = params;
         return dependencies;
     };
 
@@ -811,19 +848,44 @@ define(['esprima', './lang'], function (esprima, lang) {
     };
 
 
-    parse.findRequireDepNames = function (node, deps) {
+    parse.findRequireDepNames = function (node, deps, params) {
+        var param;
         traverse(node, function (node) {
             var arg;
 
-            if (node && node.type === 'CallExpression' && node.callee &&
-                    node.callee.type === 'Identifier' &&
-                    node.callee.name === 'require' &&
-                    node[argPropName] && node[argPropName].length === 1) {
+            if (node) {
+                if (node.type === 'CallExpression' && node.callee &&
+                        node.callee.type === 'Identifier' &&
+                        node.callee.name === 'require' &&
+                        node[argPropName] && node[argPropName].length === 1) {
 
-                arg = node[argPropName][0];
-                if (arg.type === 'Literal') {
-                    deps.push(arg.value);
+                    arg = node[argPropName][0];
+                    if (arg.type === 'Literal') {
+                        deps.push(arg.value);
+                        if (param) {
+                            params.push(param);
+                        }
+                    }
+                } else if (node.type === 'VariableDeclarator') {
+                    if (node.id && node.id.type === 'Identifier') {
+                        param = node.id.name;
+                    }
+                    return;
+                } else if (node.type === 'AssignmentExpression') {
+                    if (node.left && node.left.type === 'Identifier') {
+                        param = node.left.name;
+                    }
+                    return;
+                } else if (node.type === 'Identifier') {
+                    //Do not clear the parameter name in the current
+                    //declaration or assignment. The identifier is parsed
+                    //between the left and riht parts of the statement.
+                    return;
                 }
+            }
+            // If range or loc options are set, nodes without type occur.
+            if (node.type) {
+                param = null;
             }
         });
     };
@@ -861,6 +923,10 @@ define(['esprima', './lang'], function (esprima, lang) {
             deps = getValidDeps(arg);
             if (!deps) {
                 return;
+            }
+            factory = node[argPropName][1];
+            if (isFnExpression(factory)) {
+                deps.params = getFormalParameters(factory);
             }
 
             return onMatch("require", null, null, deps, node);
@@ -914,6 +980,9 @@ define(['esprima', './lang'], function (esprima, lang) {
 
             if (deps && deps.type === 'ArrayExpression') {
                 deps = getValidDeps(deps);
+                if (isFnExpression(factory)) {
+                    deps.params = getFormalParameters(factory);
+                }
             } else if (isFnExpression(factory)) {
                 //If no deps and a factory function, could be a commonjs sugar
                 //wrapper, scan the function for dependencies.

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -611,7 +611,6 @@ define(['esprima', './lang'], function (esprima, lang) {
      * require('stringLiteral')
      * @param {String} fileName
      * @param {String} fileContents (or astRoot)
-     * @param {Object} options
      *
      * @returns {Array} an array of dependency strings. The dependencies
      * have not been normalized, they may be relative IDs. An additional

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -876,16 +876,22 @@ define(['esprima', './lang'], function (esprima, lang) {
                         param = node.left.name;
                     }
                     return;
+                } else if (node.type === 'Property') {
+                    if (node.key && node.key.type === 'Identifier') {
+                        param = node.key.name;
+                    }
+                    return;
                 } else if (node.type === 'Identifier') {
                     //Do not clear the parameter name in the current
                     //declaration or assignment. The identifier is parsed
-                    //between the left and riht parts of the statement.
+                    //between the left and right parts of the statement.
                     return;
                 }
-            }
-            // If range or loc options are set, nodes without type occur.
-            if (node.type) {
-                param = null;
+
+                // If range or loc options are set, nodes without type occur.
+                if (node.type) {
+                    param = null;
+                }
             }
         });
     };

--- a/parse.js
+++ b/parse.js
@@ -57,6 +57,29 @@ var parse = {
       modules: dependencies,
       params: params
     }
+  },
+
+  /**
+   * Finds only CommonJS dependencies, ones that are the form 
+   * require('stringLiteral'). Expects a JavaScript module. The returned
+   * list of dependent modules and their formal parameters match in the
+   * correct code.
+   *
+   * @param  {String} contents String or Object. File contents of a CommonJS
+   * module, or an AST root produced by the `parse` method.
+   * @return {Object} Returns an object with two properties. The property
+   * "modules" is an array of dependent module paths as strings. The
+   * dependencies have not been normalized; they may be relative IDs.
+   * The property "params" is an array of formal parameter names as strings.
+   */
+  findCjsDependencies: function(contents) {
+    var dependencies = privateParse.findCjsDependencies('', contents, {}),
+        params = dependencies.params;
+    delete dependencies.params;
+    return  {
+      modules: dependencies,
+      params: params
+    }
   }
 };
 

--- a/parse.js
+++ b/parse.js
@@ -57,7 +57,7 @@ var parse = {
    * The property "params" is an array of formal parameter names as strings.
    */
   findDependencies: function(contents) {
-    var dependencies = privateParse.findDependencies('', contents, {}),
+    var dependencies = privateParse.findDependencies('', contents),
         params = dependencies.params;
     delete dependencies.params;
     return  {
@@ -80,7 +80,7 @@ var parse = {
    * The property "params" is an array of formal parameter names as strings.
    */
   findCjsDependencies: function(contents) {
-    var dependencies = privateParse.findCjsDependencies('', contents, {}),
+    var dependencies = privateParse.findCjsDependencies('', contents),
         params = dependencies.params;
     delete dependencies.params;
     return  {

--- a/parse.js
+++ b/parse.js
@@ -22,7 +22,7 @@ var parse = {
   /**
    * Walks the AST from the specified (root) node up to its leaves and calls
    * the specified callback function with two arguments - the visited node
-   * and its parent node.
+   * and its parent node. Once the callback returns `false`, traversing stops.
    *
    * @param {Object} node AST root node to start traversing with. Produced
    * by the `parse` method.
@@ -30,6 +30,20 @@ var parse = {
    */
   traverse: function (node, visitor) {
     return privateParse.traverse(node, visitor);
+  },
+
+  /**
+   * Walks the AST from the specified (root) node up to its leaves and calls
+   * the specified callback function with two arguments - the visited node
+   * and its parent node. Once the callback returns `false`, its children
+   * will be skipped and the traversing will continue with its next sibling.
+   *
+   * @param {Object} node AST root node to start traversing with. Produced
+   * by the `parse` method.
+   * @param {Function} visitor Callback receiving nodes with its parents.
+   */
+  traverseBroad: function (node, visitor) {
+    return privateParse.traverseBroad(node, visitor);
   },
 
   /**
@@ -53,7 +67,7 @@ var parse = {
     return  {
       modules: dependencies,
       params: params
-    }
+    };
   },
 
   /**
@@ -76,7 +90,7 @@ var parse = {
     return  {
       modules: dependencies,
       params: params
-    }
+    };
   }
 };
 

--- a/parse.js
+++ b/parse.js
@@ -1,0 +1,63 @@
+'use strict';
+var privateParse = require('./lib/parse');
+
+/**
+ * Functions for parsing and analysing dependencies of AMD modules. Mostly a
+ * wrapper around lib/ modules, but want to try not exposing the libs directly,
+ * and provide a cleaner interface.
+ */
+var parse = {
+  /**
+   * Parses the input JavaScript text and returns a AST of it. Expects a
+   * JavaScript content. The returned object can be used later in other calls,
+   * or to other module analysis.
+   *
+   * @param {String} contents File contents of an AMD module.
+   * @param {Object} options Optional. Options for the `esprima` parser: Only
+   * `range` and `loc` properties are recognized.
+   * @return {Object} Optional. Options for the `esprima` parser: Only `range`
+   * and `loc` properties are recognized.
+   */
+  parse: function (contents, options) {
+    return privateParse.parseFileContents('', contents, options);
+  },
+
+  /**
+   * Walks the AST from the specified (root) node up to its leaves and calls
+   * the specified callback function with two arguments - the visited node
+   * and its parent node.
+   *
+   * @param {Object} node AST root node to start traversing with. Produced
+   * by the `parse` method.
+   * @param {Function} visitor Callback receiving nodes with its parents.
+   */
+  traverse: function (node, visitor) {
+    return privateParse.traverse(node, visitor);
+  },
+
+  /**
+   * Finds all dependencies specified in the AMD module dependency array, or
+   * inside simplified CommonJS wrappers inside the module factory function.
+   * Expects a JavaScript AMD module wrapped in a `requirejs/require/define`
+   * call. The returned list of dependent modules and their formal parameters
+   * match in the correct code.
+   *
+   * @param  {String} contents String or Object. File contents of an AMD
+   * module, or an AST root produced by the `parse` method.
+   * @return {Object} Returns an object with two properties. The property
+   * "modules" is an array of dependent module paths as strings. The
+   * dependencies have not been normalized; they may be relative IDs.
+   * The property "params" is an array of formal parameter names as strings.
+   */
+  findDependencies: function(contents) {
+    var dependencies = privateParse.findDependencies('', contents, {}),
+        params = dependencies.params;
+    delete dependencies.params;
+    return  {
+      modules: dependencies,
+      params: params
+    }
+  }
+};
+
+module.exports = parse;

--- a/parse.js
+++ b/parse.js
@@ -12,11 +12,7 @@ var privateParse = require('./lib/parse');
  * (https://github.com/jquery/esprima):
  *
  * var esprima = require('esprima');
- *
- * var astRoot = esprima.parse(fileContents, {
- *   range: includeIndexBasedRangeLocation,
- *   loc: includeLineAndColumnBasedLocation
- * });
+ * var astRoot = esprima.parse(fileContents);
  */
 var parse = {
   /**

--- a/parse.js
+++ b/parse.js
@@ -5,23 +5,20 @@ var privateParse = require('./lib/parse');
  * Functions for parsing and analysing dependencies of AMD modules. Mostly a
  * wrapper around lib/ modules, but want to try not exposing the libs directly,
  * and provide a cleaner interface.
+ *
+ * If you want to obtain JavaScript AST, which is used by the methods
+ * below, use a parser producing output according to the ESTree Spec
+ * (https://github.com/estree/estree). For example, Esprima
+ * (https://github.com/jquery/esprima):
+ *
+ * var esprima = require('esprima');
+ *
+ * var astRoot = esprima.parse(fileContents, {
+ *   range: includeIndexBasedRangeLocation,
+ *   loc: includeLineAndColumnBasedLocation
+ * });
  */
 var parse = {
-  /**
-   * Parses the input JavaScript text and returns a AST of it. Expects a
-   * JavaScript content. The returned object can be used later in other calls,
-   * or to other module analysis.
-   *
-   * @param {String} contents File contents of an AMD module.
-   * @param {Object} options Optional. Options for the `esprima` parser: Only
-   * `range` and `loc` properties are recognized.
-   * @return {Object} Optional. Options for the `esprima` parser: Only `range`
-   * and `loc` properties are recognized.
-   */
-  parse: function (contents, options) {
-    return privateParse.parseFileContents('', contents, options);
-  },
-
   /**
    * Walks the AST from the specified (root) node up to its leaves and calls
    * the specified callback function with two arguments - the visited node

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -106,4 +106,27 @@ describe('parse', function() {
       assert.equal(dependencies.params[0], 'a');
     });
   });
+
+  describe('findCjsDependenccies', function() {
+    it('with an CJS module', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/cjs/controller.js'), 'utf8');
+      var dependencies = amodroParse.findCjsDependencies(content);
+      assert.equal(dependencies.modules.length, 1);
+      assert.equal(dependencies.modules[0], './model');
+      assert.equal(dependencies.params.length, 1);
+      assert.equal(dependencies.params[0], 'model');
+    });
+
+    it('with an already parsed content', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/cjs/controller.js'), 'utf8');
+      var astRoot = esprima.parse(content);
+      var dependencies = amodroParse.findCjsDependencies(astRoot);
+      assert.equal(dependencies.modules.length, 1);
+      assert.equal(dependencies.modules[0], './model');
+      assert.equal(dependencies.params.length, 1);
+      assert.equal(dependencies.params[0], 'model');
+    });
+  });
 });

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -51,7 +51,7 @@ describe('parse', function() {
   });
   
   describe('findDependenccies', function() {
-    it('with an AMD module', function() {
+    it('with an AMD main application', function() {
       var content = fs.readFileSync(path.join(__dirname,
               'source/trace/simple/main.js'), 'utf8');
       var dependencies = amodroParse.findDependencies(content);
@@ -61,7 +61,7 @@ describe('parse', function() {
       assert.equal(dependencies.params[0], 'a');
     });
 
-    it('with a CJS module', function() {
+    it('with a CJS main application', function() {
       var content = fs.readFileSync(path.join(__dirname,
               'source/trace/simple/main-cjs.js'), 'utf8');
       var dependencies = amodroParse.findDependencies(content);
@@ -71,6 +71,28 @@ describe('parse', function() {
       assert.equal(dependencies.params.length, 2);
       assert.equal(dependencies.params[0], 'require');
       assert.equal(dependencies.params[1], 'a');
+    });
+
+    it('with an AMD module', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/c.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 1);
+      assert.equal(dependencies.modules[0], 'b');
+      assert.equal(dependencies.params.length, 1);
+      assert.equal(dependencies.params[0], 'b');
+    });
+
+    it('with a CJS module', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/c-cjs.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 2);
+      assert.equal(dependencies.modules[0], 'require');
+      assert.equal(dependencies.modules[1], 'b');
+      assert.equal(dependencies.params.length, 2);
+      assert.equal(dependencies.params[0], 'require');
+      assert.equal(dependencies.params[1], 'b');
     });
 
     it('with an already parsed content', function() {

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -1,0 +1,87 @@
+/*global describe, it */
+'use strict';
+
+var amodroParse = require('../parse'),
+    assert = require('assert'),
+    esprima = require('esprima'),
+    fs = require('fs'),
+    path = require('path');
+
+describe('parse', function() {
+  describe('parse', function() {
+    var content;
+    
+    before(function() {
+      content = fs.readFileSync(path.join(__dirname,
+          'source/trace/simple/main.js'), 'utf8');
+    });
+  
+    it('without parser options', function() {
+      var astRoot = amodroParse.parse(content);
+      assert.ok(astRoot);
+    });
+
+    it('with parser options', function() {
+      var astRoot = amodroParse.parse(content, {
+        range: true,
+        loc: true
+      });
+      assert.ok(astRoot);
+      assert.ok(astRoot.range);
+      assert.ok(astRoot.loc);
+    });
+  });
+  
+  describe('traverse', function() {
+    it('visits a known node', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/main.js'), 'utf8');
+      var astRoot = esprima.parse(content);
+      var identifierNode, callNode;
+      amodroParse.traverse(astRoot, function (node, parent) {
+        if (node && node.type === 'Identifier' &&
+            node.name === 'require') {
+              identifierNode = node;
+              callNode = parent;
+            }
+      });
+      assert.ok(identifierNode);
+      assert.ok(callNode);
+    });
+  });
+  
+  describe('findDependenccies', function() {
+    it('with an AMD module', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/main.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 1);
+      assert.equal(dependencies.modules[0], 'a');
+      assert.equal(dependencies.params.length, 1);
+      assert.equal(dependencies.params[0], 'a');
+    });
+
+    it('with a CJS module', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/main-cjs.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 2);
+      assert.equal(dependencies.modules[0], 'require');
+      assert.equal(dependencies.modules[1], 'a');
+      assert.equal(dependencies.params.length, 2);
+      assert.equal(dependencies.params[0], 'require');
+      assert.equal(dependencies.params[1], 'a');
+    });
+
+    it('with an already parsed content', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/main.js'), 'utf8');
+      var astRoot = esprima.parse(content);
+      var dependencies = amodroParse.findDependencies(astRoot);
+      assert.equal(dependencies.modules.length, 1);
+      assert.equal(dependencies.modules[0], 'a');
+      assert.equal(dependencies.params.length, 1);
+      assert.equal(dependencies.params[0], 'a');
+    });
+  });
+});

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -155,6 +155,38 @@ describe('parse', function() {
       assert.equal(dependencies.params.length, 1);
       assert.equal(dependencies.params[0], 'a');
     });
+
+    it('with a module exporting an object literal', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/module-object-only.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 0);
+      assert.equal(dependencies.params.length, 0);
+    });
+
+    it('with a module with "explicitly" empty dependencies', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/module-empty-deps.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 0);
+      assert.equal(dependencies.params.length, 0);
+    });
+
+    it('with an application passing an object literal', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/app-object-only.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 0);
+      assert.equal(dependencies.params.length, 0);
+    });
+
+    it('withn an application with "explicitly" empty dependencies', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/app-empty-deps.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 0);
+      assert.equal(dependencies.params.length, 0);
+    });
   });
 
   describe('findCjsDependenccies', function() {

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -8,30 +8,6 @@ var amodroParse = require('../parse'),
     path = require('path');
 
 describe('parse', function() {
-  describe('parse', function() {
-    var content;
-    
-    before(function() {
-      content = fs.readFileSync(path.join(__dirname,
-          'source/trace/simple/main.js'), 'utf8');
-    });
-  
-    it('without parser options', function() {
-      var astRoot = amodroParse.parse(content);
-      assert.ok(astRoot);
-    });
-
-    it('with parser options', function() {
-      var astRoot = amodroParse.parse(content, {
-        range: true,
-        loc: true
-      });
-      assert.ok(astRoot);
-      assert.ok(astRoot.range);
-      assert.ok(astRoot.loc);
-    });
-  });
-  
   describe('traverse', function() {
     it('visits a known node', function() {
       var content = fs.readFileSync(path.join(__dirname,
@@ -49,7 +25,7 @@ describe('parse', function() {
       assert.ok(callNode);
     });
   });
-  
+
   describe('findDependenccies', function() {
     it('with an AMD main application', function() {
       var content = fs.readFileSync(path.join(__dirname,

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -1,4 +1,4 @@
-/*global describe, it */
+/*global describe, before, it */
 'use strict';
 
 var amodroParse = require('../parse'),
@@ -9,12 +9,16 @@ var amodroParse = require('../parse'),
 
 describe('parse', function() {
   describe('traverse', function() {
-    it('visits a known node', function() {
+    before(function() {
       var content = fs.readFileSync(path.join(__dirname,
               'source/trace/simple/main.js'), 'utf8');
-      var astRoot = esprima.parse(content);
-      var identifierNode, callNode;
-      amodroParse.traverse(astRoot, function (node, parent) {
+      this.astRoot = esprima.parse(content);
+    });
+
+    it('visits a known node', function() {
+      var identifierNode, callNode, lastNode;
+      amodroParse.traverse(this.astRoot, function (node, parent) {
+        lastNode = node;
         if (node && node.type === 'Identifier' &&
             node.name === 'require') {
               identifierNode = node;
@@ -23,6 +27,76 @@ describe('parse', function() {
       });
       assert.ok(identifierNode);
       assert.ok(callNode);
+      assert.ok(identifierNode !== lastNode);
+    });
+
+    it('stops traversing, once the visitor returns `true`', function() {
+      var identifierNode, lastNode;
+      amodroParse.traverse(this.astRoot, function (node) {
+        lastNode = node;
+        if (node && node.type === 'Identifier' &&
+            node.name === 'require') {
+              identifierNode = node;
+              return false;
+            }
+      });
+      assert.ok(identifierNode);
+      assert.ok(identifierNode === lastNode);
+    });
+  });
+
+  describe('traverseBroad', function() {
+    before(function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/nested/a.js'), 'utf8');
+      this.astRoot = esprima.parse(content);
+    });
+
+    it('visits known nodes', function() {
+      var defineNode, requireNode, argumentNode, returnNode;
+      amodroParse.traverseBroad(this.astRoot, function (node, parent) {
+        if (node && node.type === 'ExpressionStatement' &&
+            node.expression && node.expression.type === 'CallExpression' &&
+            node.expression.callee &&
+            node.expression.callee.type === 'Identifier' &&
+            node.expression.callee.name === 'require') {
+              requireNode = node;
+              defineNode = parent;
+            }
+        if (node && node.type === 'Literal' && node.value === 'e') {
+              argumentNode = node;
+            }
+        if (node && node.type === 'ReturnStatement') {
+              returnNode = node;
+            }
+      });
+      assert.ok(defineNode);
+      assert.ok(requireNode);
+      assert.ok(argumentNode);
+      assert.ok(returnNode);
+    });
+
+    it('skips traversing children, if the visitor returns `true`', function() {
+      var requireNode, argumentNode, returnNode;
+      amodroParse.traverseBroad(this.astRoot, function (node, parent) {
+        if (node && node.type === 'ExpressionStatement' &&
+            node.expression && node.expression.type === 'CallExpression' &&
+            node.expression.callee &&
+            node.expression.callee.type === 'Identifier' &&
+            node.expression.callee.name === 'require') {
+              requireNode = node;
+              return false;
+            }
+        if (node && node.type === 'Literal' && node.value === 'e') {
+              argumentNode = node;
+            }
+        if (node && node.type === 'ReturnStatement') {
+              returnNode = node;
+            }
+      });
+      assert.ok(requireNode);
+      assert.ok(!argumentNode);
+      assert.ok(returnNode);
     });
   });
 

--- a/test/source/trace/simple/app-empty-deps.js
+++ b/test/source/trace/simple/app-empty-deps.js
@@ -1,0 +1,3 @@
+'use strict';
+require([], function () {
+});

--- a/test/source/trace/simple/app-object-only.js
+++ b/test/source/trace/simple/app-object-only.js
@@ -1,0 +1,4 @@
+'use strict';
+require({
+  name: 'test'
+});

--- a/test/source/trace/simple/c-cjs.js
+++ b/test/source/trace/simple/c-cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+define(function(require) {
+  var b = require('b');
+  return {};
+});

--- a/test/source/trace/simple/c.js
+++ b/test/source/trace/simple/c.js
@@ -1,0 +1,4 @@
+'use strict';
+define(['b'], function(b) {
+  return {};
+});

--- a/test/source/trace/simple/main-cjs.js
+++ b/test/source/trace/simple/main-cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+define(function(require) {
+  var a = require('a');
+  console.log(a);
+});

--- a/test/source/trace/simple/main-cjs.js
+++ b/test/source/trace/simple/main-cjs.js
@@ -1,5 +1,5 @@
 'use strict';
-define(function(require) {
+require(function(require) {
   var a = require('a');
   console.log(a);
 });

--- a/test/source/trace/simple/module-empty-deps.js
+++ b/test/source/trace/simple/module-empty-deps.js
@@ -1,0 +1,3 @@
+'use strict';
+define([], function () {
+});

--- a/test/source/trace/simple/module-object-only.js
+++ b/test/source/trace/simple/module-object-only.js
@@ -1,0 +1,4 @@
+'use strict';
+define({
+  name: 'test'
+});


### PR DESCRIPTION
Attempts to fix #13  by introducing `amodro-trace/parse`.

**`parse: function (contents, options)`**

Exposes `parseFileContents` from `lib/parse`.

Extension: Add method `parseFileContents` to `lib/parse` as a thin wrapper of
`esprima.parse`. Abstract the client from Esprima and saves it from
having a direct dependency on `esprima`.

**`traverse: function (node, visitor)`**

Exposes `traverse` from `lib/parse`.

Extension: Pass parent node to visitors of traverse and traverseBroad too. Help
scenarios, when just knowing the parent is enough and generating the
parent link in every node as an extra parsing step is not needed.

**`findDependencies: function(contents)`**

Exposes `findDependencies` from `lib/parse`.

Extension: Make method `findDependencies` accept an already parsed astRoot too. If
the astRot has been already parsed for other purposes, no need to do it
again.

Extension: Make method `findDependencies` return not only the list of dependent modules, but also the list of formal parameters assigned to exports of the dependent modules, if there are any.

**`findCjsDependencies: function(contents)`**

Exposes `findCjsDependencies` from `lib/parse` with the same extensions as done for `findDependencies` above.

**Note:** In addition to the list of dependent modules, I need also the formal parameter names, to be able to identify, which variable represents the dependent module export in the current module. It is naturally available, when parsing the `define` or `require` function prototypes. I didn't rewrite multiple methods inside `lib/parse`, which return an array of module names, to return an object with two arrays. I just returned the parameter names on the result array as `.params`. Public methods in `amodro-trace/parse` return the modules and parameters as an object: `{modules, params}`.

 I added documentation and unit tests to "whet your appetite" :-)