### PR TITLE
Perform jshint checks within the "npm test" command, fix warnings

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,7 @@
   "quotmark": "single",
   "undef": true,
   "unused": "vars",
-  "strict": true,
+  "strict": false,
   "trailing": true,
   "maxlen": 80,
 

--- a/README.md
+++ b/README.md
@@ -517,10 +517,58 @@ var config = require('amodro-config')
 
 Arguments to `modify`:
 
-* **contents**: String. File conents that may contain a config call.
+* **contents**: String. File contents that may contain a config call.
 * **onConfig**: Function. Function called when the first config call is found. It will be passed an Object which is the current config, and the onConfig function should return an Object to use as the new config that will be serialized into the contents, replacing the old config.
 
 Returns a String the contents with the config changes applied.
+
+### amodro-trace/parse
+
+This module helps to extract dependencies from a JS file, which is an AMD module - which is wrapped in a `require` or a `define` statemenet. The API methods on this module:
+
+#### parse.parse
+
+Parses the input JavaScript text and returns an AST of it. Expects a JavaScript content. The returned object can be used later in other calls, or to other module analysis.
+
+```javascript
+var astRoot = require('amodro-trace/parse').parse(contents, options);
+```
+
+Aruguments to `parse`:
+
+* **contents**: String. File contents of an AMD module.
+* **options**: Object. Optional. Options for the `esprima` parser: Only `range` and `loc` properties are recognized.
+
+Returns an Object with the JavaScript AST build from the module contents.
+
+#### parse.traverse
+
+Walks the AST from the specified (root) node up to its leaves and calls the specified callback function with two arguments - the visited node and its parent node.
+
+```javascript
+require('amodro-trace/parse').traverse(rootNode, function (node, parent) {
+  ...
+});
+```
+
+Aruguments to `traverse`:
+
+* **node**: Object. AST root node to start traversing with. Produced by the `parse` method.
+* **visitor**: Function. Callback receiving nodes with its parents.
+
+#### parse.findDependencies
+
+Finds all dependencies specified in the AMD module dependency array, or inside simplified CommonJS wrappers inside the module factory function. Expects a JavaScript AMD module wrapped in a `requirejs/require/define` call. The returned list of dependent modules and their formal parameters match in the correct code.
+
+```javascript
+var dependencies = require('amodro-trace/parse').findDependencies(contents);
+```
+
+Aruguments to `findDependencies`:
+
+* **contents**: String or Object. File contents of an AMD module, or an AST root produced by the `parse` method.
+
+Returns an object with two properties. The property "modules" is an array of dependent module paths as strings. The dependencies have not been normalized; they may be relative IDs. The property "params" is an array of formal parameter names as strings.
 
 ## Read transforms
 

--- a/README.md
+++ b/README.md
@@ -524,7 +524,20 @@ Returns a String the contents with the config changes applied.
 
 ### amodro-trace/parse
 
-This module helps to extract dependencies from a JS file, which is an AMD module - which is wrapped in a `require` or a `define` statemenet. The API methods on this module:
+This module helps to extract dependencies from a JS file, which is an AMD module - which is wrapped in a `require` or a `define` statement.
+
+Methods accept either a string with the source content or an object  with JavaScript AST. If you traverse the AST multiple times, you can improve performance by parsing the source just once by a parser producing output according to the [ESTree Spec](https://github.com/estree/estree). For example, [Esprima](https://github.com/jquery/esprima):
+
+```javascript
+var esprima = require('esprima');
+
+var astRoot = esprima.parse(fileContents, {
+  range: includeIndexBasedRangeLocation,
+  loc: includeLineAndColumnBasedLocation
+});
+```
+
+The API methods on this module:
 
 #### parse.parse
 
@@ -534,7 +547,7 @@ Parses the input JavaScript text and returns an AST of it. Expects a JavaScript 
 var astRoot = require('amodro-trace/parse').parse(contents, options);
 ```
 
-Aruguments to `parse`:
+Arguments to `parse`:
 
 * **contents**: String. File contents of an AMD module.
 * **options**: Object. Optional. Options for the `esprima` parser: Only `range` and `loc` properties are recognized.
@@ -551,7 +564,7 @@ require('amodro-trace/parse').traverse(rootNode, function (node, parent) {
 });
 ```
 
-Aruguments to `traverse`:
+Arguments to `traverse`:
 
 * **node**: Object. AST root node to start traversing with. Produced by the `parse` method.
 * **visitor**: Function. Callback receiving nodes with its parents.
@@ -564,7 +577,7 @@ Finds all dependencies specified in the AMD module dependency array, or inside s
 var dependencies = require('amodro-trace/parse').findDependencies(contents);
 ```
 
-Aruguments to `findDependencies`:
+Arguments to `findDependencies`:
 
 * **contents**: String or Object. File contents of an AMD module, or an AST root produced by the `parse` method.
 
@@ -578,7 +591,7 @@ Finds only CommonJS dependencies, ones that are the form  `require('stringLitera
 var dependencies = require('amodro-trace/parse').findCjsDependencies(contents);
 ```
 
-Aruguments to `findCjsDependencies`:
+Arguments to `findCjsDependencies`:
 
 * **contents**: String or Object. File contents of a CommonJS module, or an AST root produced by the `parse` method.
 

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ Returns an Object with the JavaScript AST build from the module contents.
 
 #### parse.traverse
 
-Walks the AST from the specified (root) node up to its leaves and calls the specified callback function with two arguments - the visited node and its parent node.
+Walks the AST from the specified (root) node up to its leaves and calls the specified callback function with two arguments - the visited node and its parent node. Once the callback returns `false`, traversing stops.
 
 ```javascript
 require('amodro-trace/parse').traverse(rootNode, function (node, parent) {
@@ -564,7 +564,22 @@ require('amodro-trace/parse').traverse(rootNode, function (node, parent) {
 });
 ```
 
-Arguments to `traverse`:
+Arguments to `traverseBroad`:
+
+* **node**: Object. AST root node to start traversing with. Produced by the `parse` method.
+* **visitor**: Function. Callback receiving nodes with its parents.
+
+#### parse.traverseBroad
+
+Walks the AST from the specified (root) node up to its leaves and calls the specified callback function with two arguments - the visited node and its parent node. Once the callback returns `false`, its children will be skipped and the traversing will continue with its next sibling.
+
+```javascript
+require('amodro-trace/parse').traverseBroad(rootNode, function (node, parent) {
+  ...
+});
+```
+
+Arguments to `traverseBroad`:
 
 * **node**: Object. AST root node to start traversing with. Produced by the `parse` method.
 * **visitor**: Function. Callback receiving nodes with its parents.

--- a/README.md
+++ b/README.md
@@ -570,6 +570,20 @@ Aruguments to `findDependencies`:
 
 Returns an object with two properties. The property "modules" is an array of dependent module paths as strings. The dependencies have not been normalized; they may be relative IDs. The property "params" is an array of formal parameter names as strings.
 
+#### parse.findCjsDependencies
+
+Finds only CommonJS dependencies, ones that are the form  `require('stringLiteral')`. Expects a JavaScript module. The returned list of dependent modules and their formal parameters match in the correct code.
+
+```javascript
+var dependencies = require('amodro-trace/parse').findCjsDependencies(contents);
+```
+
+Aruguments to `findCjsDependencies`:
+
+* **contents**: String or Object. File contents of a CommonJS module, or an AST root produced by the `parse` method.
+
+Returns an object with two properties. The property "modules" is an array of dependent module paths as strings. The dependencies have not been normalized; they may be relative IDs. The property "params" is an array of formal parameter names as strings.
+
 ## Read transforms
 
 See the [readTransform](#readtransform) option for background on read transforms. This section describes read transforms provided by this project.

--- a/lib/lang.js
+++ b/lib/lang.js
@@ -7,7 +7,7 @@ var define = function(fn) { module.exports = fn(); };
  */
 
 /*jslint plusplus: true */
-/*global define, java */
+/*global java */
 
 define(function () {
     'use strict';
@@ -25,7 +25,8 @@ define(function () {
 
     //Rhino, but not Nashorn (detected by importPackage not existing)
     //Can have some strange foreign objects.
-    if (typeof java !== 'undefined' && java.lang && java.lang.Object && typeof importPackage !== 'undefined') {
+    if (typeof java !== 'undefined' && java.lang && java.lang.Object &&
+        typeof importPackage !== 'undefined') {
         isJavaObj = function (obj) {
             return obj instanceof java.lang.Object;
         };
@@ -46,11 +47,11 @@ define(function () {
         ostring: Object.prototype.toString,
 
         isArray: Array.isArray || function (it) {
-            return lang.ostring.call(it) === "[object Array]";
+            return lang.ostring.call(it) === '[object Array]';
         },
 
         isFunction: function(it) {
-            return lang.ostring.call(it) === "[object Function]";
+            return lang.ostring.call(it) === '[object Function]';
         },
 
         isRegExp: function(it) {
@@ -92,7 +93,8 @@ define(function () {
 
             if (!dest) { dest = {}; }
 
-            if (parameters.length > 2 && typeof arguments[parameters.length-1] === 'boolean') {
+            if (parameters.length > 2 &&
+                typeof arguments[parameters.length-1] === 'boolean') {
                 override = parameters.pop();
             }
 
@@ -150,8 +152,8 @@ define(function () {
 
             type = typeof obj;
             if (obj === null || obj === undefined || type === 'boolean' ||
-                type === 'string' || type === 'number' || lang.isFunction(obj) ||
-                lang.isRegExp(obj)|| isJavaObj(obj)) {
+                type === 'string' || type === 'number' ||
+                lang.isFunction(obj) || lang.isRegExp(obj)|| isJavaObj(obj)) {
                 return obj;
             }
 
@@ -220,11 +222,11 @@ define(function () {
         //for inclusion as part of a JS string.
         jsEscape: function (content) {
             return content.replace(/(["'\\])/g, '\\$1')
-                .replace(/[\f]/g, "\\f")
-                .replace(/[\b]/g, "\\b")
-                .replace(/[\n]/g, "\\n")
-                .replace(/[\t]/g, "\\t")
-                .replace(/[\r]/g, "\\r");
+                .replace(/[\f]/g, '\\f')
+                .replace(/[\b]/g, '\\b')
+                .replace(/[\n]/g, '\\n')
+                .replace(/[\t]/g, '\\t')
+                .replace(/[\r]/g, '\\r');
         }
     };
     return lang;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -905,7 +905,7 @@ define(['esprima', './lang'], function (esprima, lang) {
      * Otherwise null.
      */
     parse.parseNode = function (node, onMatch, fnExpScope) {
-        var name, deps, cjsDeps, arg, factory, exp, refsDefine, bodyNode,
+        var name, deps, cjsDeps, arg, factoryIndex, factory, exp, refsDefine, bodyNode,
             args = node && node[argPropName],
             callName = parse.hasRequire(node),
             isUmd = false;
@@ -913,20 +913,32 @@ define(['esprima', './lang'], function (esprima, lang) {
         if (callName === 'require' || callName === 'requirejs') {
             //A plain require/requirejs call
             arg = node[argPropName] && node[argPropName][0];
-            if (arg && arg.type !== 'ArrayExpression') {
+            if (arg) {
                 if (arg.type === 'ObjectExpression') {
                     //A config call, try the second arg.
                     arg = node[argPropName][1];
+                    factoryIndex = 2;
+                } else {
+                    factoryIndex = 1;
                 }
-            }
-
-            deps = getValidDeps(arg);
-            if (!deps) {
-                return;
-            }
-            factory = node[argPropName][1];
-            if (isFnExpression(factory)) {
-                deps.params = getFormalParameters(factory);
+                if (arg.type === 'ArrayExpression') {
+                    deps = getValidDeps(arg);
+                    if (!deps) {
+                        return;
+                    }
+                    factory = node[argPropName][factoryIndex];
+                    if (isFnExpression(factory)) {
+                        deps.params = getFormalParameters(factory);
+                    }
+                } else if (isFnExpression(arg)) {
+                    //If no deps and a factory function, could be a commonjs sugar
+                    //wrapper, scan the function for dependencies.
+                    cjsDeps = parse.getAnonDepsFromNode(arg);
+                    if (!cjsDeps.length) {
+                        return;
+                    }
+                    deps = cjsDeps;
+                }
             }
 
             return onMatch("require", null, null, deps, node);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -207,21 +207,6 @@ define(['esprima', './lang'], function (esprima, lang) {
         return result || null;
     }
 
-    /**
-     * Just parses the text to an AST to be used in other methods.
-     * @param {String} fileName
-     * @param {String} fileContents
-     * @param {Object} options
-     * @returns {Object} AST
-     */
-    parse.parseFileContents = function (fileName, fileContents, options) {
-        var localOptions = options || {};
-        return esprima.parse(fileContents, {
-            range: localOptions.range,
-            loc: localOptions.loc
-        });
-    }
-
     parse.traverse = traverse;
     parse.traverseBroad = traverseBroad;
     parse.isFnExpression = isFnExpression;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -65,7 +65,7 @@ define(['esprima', './lang'], function (esprima, lang) {
             return false;
         }
         for (var i = 0, keys = Object.keys(object); i < keys.length; i++) {
-            child = object[key];
+            child = object[keys[i]];
             if (typeof child === 'object' && child !== null) {
                 traverseBroad(child, visitor, object);
             }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -6,7 +6,6 @@ var define = function(ary, fn) {
 };
 
 /*jslint plusplus: true */
-/*global define: false */
 define(['esprima', './lang'], function (esprima, lang) {
     'use strict';
 
@@ -143,7 +142,8 @@ define(['esprima', './lang'], function (esprima, lang) {
             needsDefine = true,
             astRoot = esprima.parse(fileContents);
 
-        parse.recurse(astRoot, function (callName, config, name, deps, node, factoryIdentifier, fnExpScope) {
+        parse.recurse(astRoot, function (callName, config, name, deps, node,
+                factoryIdentifier, fnExpScope) {
             if (!deps) {
                 deps = [];
             }
@@ -163,7 +163,8 @@ define(['esprima', './lang'], function (esprima, lang) {
                 });
             }
 
-            if (callName === 'define' && factoryIdentifier && hasProp(fnExpScope, factoryIdentifier)) {
+            if (callName === 'define' && factoryIdentifier &&
+                hasProp(fnExpScope, factoryIdentifier)) {
                 return factoryIdentifier;
             }
 
@@ -257,13 +258,15 @@ define(['esprima', './lang'], function (esprima, lang) {
             //wrapped function expression argument.
             //Catch (function(a) {... wrappers
             if (object.type === 'ExpressionStatement' && object.expression &&
-                    object.expression.type === 'CallExpression' && object.expression.callee &&
+                    object.expression.type === 'CallExpression' &&
+                    object.expression.callee &&
                     isFnExpression(object.expression.callee)) {
                 tempObject = object.expression.callee;
             }
             // Catch !function(a) {... wrappers
             if (object.type === 'UnaryExpression' && object.argument &&
-                object.argument.type === 'CallExpression' && object.argument.callee &&
+                object.argument.type === 'CallExpression' &&
+                object.argument.callee &&
                 isFnExpression(object.argument.callee)) {
                 tempObject = object.argument.callee;
             }
@@ -282,10 +285,12 @@ define(['esprima', './lang'], function (esprima, lang) {
                 child = object[keys[i]];
                 if (typeof child === 'object' && child !== null) {
                     result = this.recurse(child, onMatch, options, fnExpScope);
-                    if (typeof result === 'string' && hasProp(fnExpScope, result)) {
-                        //The result was still in fnExpScope so break. Otherwise,
-                        //was a return from a a tree that had a UMD definition,
-                        //but now out of that scope so keep siblings.
+                    if (typeof result === 'string' &&
+                        hasProp(fnExpScope, result)) {
+                        //The result was still in fnExpScope so break.
+                        //Otherwise, was a return from a a tree that had
+                        //a UMD definition, but now out of that scope so
+                        // keep siblings.
                         break;
                     }
                 }
@@ -327,10 +332,11 @@ define(['esprima', './lang'], function (esprima, lang) {
                         var decls = bodyNode.declarations;
                         if (decls) {
                             var hasVarDefine = decls.some(function(declNode) {
-                                return (declNode.type === 'VariableDeclarator' &&
-                                        declNode.id &&
-                                        declNode.id.type === 'Identifier' &&
-                                        declNode.id.name === 'define');
+                                return (
+                                    declNode.type === 'VariableDeclarator' &&
+                                    declNode.id &&
+                                    declNode.id.type === 'Identifier' &&
+                                    declNode.id.name === 'define');
                             });
                             if (hasVarDefine) {
                                 return true;
@@ -405,8 +411,8 @@ define(['esprima', './lang'], function (esprima, lang) {
             //over the return value of the function, so only add it if asked.
             funcArgLength = node.params && node.params.length;
             if (funcArgLength) {
-                deps = (funcArgLength > 1 ? ["require", "exports", "module"] :
-                        ["require"]).concat(deps);
+                deps = (funcArgLength > 1 ? ['require', 'exports', 'module'] :
+                        ['require']).concat(deps);
                 params = getFormalParameters(node).concat(params);
             }
         }
@@ -528,11 +534,11 @@ define(['esprima', './lang'], function (esprima, lang) {
     };
 
     /**
-     * Renames require/requirejs/define calls to be ns + '.' + require/requirejs/define
-     * Does *not* do .config calls though. See pragma.namespace for the complete
-     * set of namespace transforms. This function is used because require calls
-     * inside a define() call should not be renamed, so a simple regexp is not
-     * good enough.
+     * Renames require/requirejs/define calls to be ns + '.' +
+     * require/requirejs/define. Does *not* do .config calls though.
+     * See pragma.namespace for the complete set of namespace transforms.
+     * This function is used because require calls inside a define() call
+     * should not be renamed, so a simple regexp is not good enough.
      * @param  {String} fileContents the contents to transform.
      * @param  {String} ns the namespace, *not* including trailing dot.
      * @return {String} the fileContents with the namespace applied
@@ -711,16 +717,19 @@ define(['esprima', './lang'], function (esprima, lang) {
     parse.getAllNamedDefines = function (fileContents, excludeMap) {
         var names = [];
         parse.recurse(esprima.parse(fileContents),
-        function (callName, config, name, deps, node, factoryIdentifier, fnExpScope) {
+        function (callName, config, name, deps, node, factoryIdentifier,
+                fnExpScope) {
             if (callName === 'define' && name) {
                 if (!excludeMap.hasOwnProperty(name)) {
                     names.push(name);
                 }
             }
 
-            //If a UMD definition that points to a factory that is an Identifier,
-            //indicate processing should not traverse inside the UMD definition.
-            if (callName === 'define' && factoryIdentifier && hasProp(fnExpScope, factoryIdentifier)) {
+            //If a UMD definition that points to a factory that is an
+            //Identifier, indicate processing should not traverse inside
+            //the UMD definition.
+            if (callName === 'define' && factoryIdentifier &&
+                hasProp(fnExpScope, factoryIdentifier)) {
                 return factoryIdentifier;
             }
 
@@ -896,7 +905,8 @@ define(['esprima', './lang'], function (esprima, lang) {
      * Otherwise null.
      */
     parse.parseNode = function (node, onMatch, fnExpScope) {
-        var name, deps, cjsDeps, arg, factoryIndex, factory, exp, refsDefine, bodyNode,
+        var name, deps, cjsDeps, arg, factoryIndex, factory, exp, refsDefine,
+            bodyNode,
             args = node && node[argPropName],
             callName = parse.hasRequire(node),
             isUmd = false;
@@ -922,8 +932,8 @@ define(['esprima', './lang'], function (esprima, lang) {
                         deps.params = getFormalParameters(factory);
                     }
                 } else if (isFnExpression(arg)) {
-                    //If no deps and a factory function, could be a commonjs sugar
-                    //wrapper, scan the function for dependencies.
+                    //If no deps and a factory function, could be a commonjs
+                    //sugar wrapper, scan the function for dependencies.
                     cjsDeps = parse.getAnonDepsFromNode(arg);
                     if (!cjsDeps.length) {
                         return;
@@ -932,7 +942,7 @@ define(['esprima', './lang'], function (esprima, lang) {
                 }
             }
 
-            return onMatch("require", null, null, deps, node);
+            return onMatch('require', null, null, deps, node);
         } else if (parse.hasDefine(node) && args && args.length) {
             name = args[0];
             deps = args[1];
@@ -1003,8 +1013,9 @@ define(['esprima', './lang'], function (esprima, lang) {
                 name = name.value;
             }
 
-            return onMatch("define", null, name, deps, node,
-                           (factory && factory.type === 'Identifier' ? factory.name : undefined),
+            return onMatch('define', null, name, deps, node,
+                           (factory && factory.type === 'Identifier' ?
+                            factory.name : undefined),
                            fnExpScope);
         } else if (node.type === 'CallExpression' && node.callee &&
                    isFnExpression(node.callee) &&
@@ -1032,8 +1043,9 @@ define(['esprima', './lang'], function (esprima, lang) {
                     });
 
                     if (refsDefine) {
-                        return onMatch("define", null, null, null, exp.expression,
-                                       exp.expression.arguments[0].name, fnExpScope);
+                        return onMatch('define', null, null, null,
+                            exp.expression, exp.expression.arguments[0].name,
+                            fnExpScope);
                     }
                 }
             }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -624,24 +624,24 @@ define(['esprima', './lang'], function (esprima, lang) {
     /**
      * Finds only CJS dependencies, ones that are the form
      * require('stringLiteral')
+     * @param {String} fileName
+     * @param {String} fileContents (or astRoot)
+     * @param {Object} options
+     *
+     * @returns {Array} an array of dependency strings. The dependencies
+     * have not been normalized, they may be relative IDs. An additional
+     * array of Formal parameter names is available as the property "params"
+     * on the returned array.
      */
     parse.findCjsDependencies = function (fileName, fileContents) {
-        var dependencies = [];
+        var dependencies = [],
+            params = [],
+            astRoot = typeof fileContents === 'string' ?
+                      esprima.parse(fileContents) : fileContents;
 
-        traverse(esprima.parse(fileContents), function (node) {
-            var arg;
+        this.findRequireDepNames(astRoot, dependencies, params);
 
-            if (node && node.type === 'CallExpression' && node.callee &&
-                    node.callee.type === 'Identifier' &&
-                    node.callee.name === 'require' && node[argPropName] &&
-                    node[argPropName].length === 1) {
-                arg = node[argPropName][0];
-                if (arg.type === 'Literal') {
-                    dependencies.push(arg.value);
-                }
-            }
-        });
-
+        dependencies.params = params;
         return dependencies;
     };
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -908,12 +908,17 @@ define(['esprima', './lang'], function (esprima, lang) {
                 if (arg.type === 'ObjectExpression') {
                     //A config call, try the second arg.
                     arg = node[argPropName][1];
+                    //Guard against expressions like "require({})"
+                    if (!arg) {
+                        return;
+                    }
                     factoryIndex = 2;
                 } else {
                     factoryIndex = 1;
                 }
                 if (arg.type === 'ArrayExpression') {
                     deps = getValidDeps(arg);
+                    //Guard against expressions like "require([], function(){})"
                     if (!deps) {
                         return;
                     }
@@ -983,6 +988,10 @@ define(['esprima', './lang'], function (esprima, lang) {
 
             if (deps && deps.type === 'ArrayExpression') {
                 deps = getValidDeps(deps);
+                //Guard against expressions like "define([], function(){})"
+                if (!deps) {
+                    return;
+                }
                 if (isFnExpression(factory)) {
                     deps.params = getFormalParameters(factory);
                 }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -31,20 +31,20 @@ define(['esprima', './lang'], function (esprima, lang) {
         hasProp = lang.hasProp;
 
     //From an esprima example for traversing its ast.
-    function traverse(object, visitor) {
+    function traverse(object, visitor, parent) {
         var child;
 
         if (!object) {
             return;
         }
 
-        if (visitor.call(null, object) === false) {
+        if (visitor.call(null, object, parent) === false) {
             return false;
         }
         for (var i = 0, keys = Object.keys(object); i < keys.length; i++) {
             child = object[keys[i]];
             if (typeof child === 'object' && child !== null) {
-                if (traverse(child, visitor) === false) {
+                if (traverse(child, visitor, object) === false) {
                     return false;
                 }
             }
@@ -54,20 +54,20 @@ define(['esprima', './lang'], function (esprima, lang) {
     //Like traverse, but visitor returning false just
     //stops that subtree analysis, not the rest of tree
     //visiting.
-    function traverseBroad(object, visitor) {
+    function traverseBroad(object, visitor, parent) {
         var child;
 
         if (!object) {
             return;
         }
 
-        if (visitor.call(null, object) === false) {
+        if (visitor.call(null, object, parent) === false) {
             return false;
         }
         for (var i = 0, keys = Object.keys(object); i < keys.length; i++) {
             child = object[key];
             if (typeof child === 'object' && child !== null) {
-                traverseBroad(child, visitor);
+                traverseBroad(child, visitor, object);
             }
         }
     }
@@ -105,6 +105,16 @@ define(['esprima', './lang'], function (esprima, lang) {
         return (node && (node.type === 'FunctionExpression' ||
                              node.type === 'ArrowFunctionExpression'));
     }
+
+    // Returns an array of formal parameter names of the specified factory
+    // function.
+    function getFormalParameters(factory) {
+        return (factory && factory.params || []).filter(function (param) {
+            return param.type === 'Identifier';
+        }).map(function (param) {
+            return param.name;
+        });
+   }
 
     /**
      * Main parse function. Returns a string of any valid require or
@@ -195,6 +205,21 @@ define(['esprima', './lang'], function (esprima, lang) {
         }
 
         return result || null;
+    }
+
+    /**
+     * Just parses the text to an AST to be used in other methods.
+     * @param {String} fileName
+     * @param {String} fileContents
+     * @param {Object} options
+     * @returns {Object} AST
+     */
+    parse.parseFileContents = function (fileName, fileContents, options) {
+        var localOptions = options || {};
+        return esprima.parse(fileContents, {
+            range: localOptions.range,
+            loc: localOptions.loc
+        });
     }
 
     parse.traverse = traverse;
@@ -383,10 +408,11 @@ define(['esprima', './lang'], function (esprima, lang) {
      */
     parse.getAnonDepsFromNode = function (node) {
         var deps = [],
+            params = [],
             funcArgLength;
 
         if (node) {
-            this.findRequireDepNames(node, deps);
+            this.findRequireDepNames(node, deps, params);
 
             //If no deps, still add the standard CommonJS require, exports,
             //module, in that order, to the deps, but only if specified as
@@ -396,8 +422,10 @@ define(['esprima', './lang'], function (esprima, lang) {
             if (funcArgLength) {
                 deps = (funcArgLength > 1 ? ["require", "exports", "module"] :
                         ["require"]).concat(deps);
+                params = getFormalParameters(node).concat(params);
             }
         }
+        deps.params = params;
         return deps;
     };
 
@@ -566,21 +594,30 @@ define(['esprima', './lang'], function (esprima, lang) {
      * Finds all dependencies specified in dependency arrays and inside
      * simplified commonjs wrappers.
      * @param {String} fileName
-     * @param {String} fileContents
+     * @param {String} fileContents (or astRoot)
+     * @param {Object} options
      *
      * @returns {Array} an array of dependency strings. The dependencies
-     * have not been normalized, they may be relative IDs.
+     * have not been normalized, they may be relative IDs. An additional
+     * array of Formal parameter names is available as the property "params"
+     * on the returned array.
      */
     parse.findDependencies = function (fileName, fileContents, options) {
         var dependencies = [],
-            astRoot = esprima.parse(fileContents);
+            params = [],
+            astRoot = typeof fileContents === 'string' ?
+                      esprima.parse(fileContents) : fileContents;
 
         parse.recurse(astRoot, function (callName, config, name, deps) {
             if (deps) {
                 dependencies = dependencies.concat(deps);
+                if (deps.params) {
+                    params = params.concat(deps.params);
+                }
             }
         }, options);
 
+        dependencies.params = params;
         return dependencies;
     };
 
@@ -811,19 +848,44 @@ define(['esprima', './lang'], function (esprima, lang) {
     };
 
 
-    parse.findRequireDepNames = function (node, deps) {
+    parse.findRequireDepNames = function (node, deps, params) {
+        var param;
         traverse(node, function (node) {
             var arg;
 
-            if (node && node.type === 'CallExpression' && node.callee &&
-                    node.callee.type === 'Identifier' &&
-                    node.callee.name === 'require' &&
-                    node[argPropName] && node[argPropName].length === 1) {
+            if (node) {
+                if (node.type === 'CallExpression' && node.callee &&
+                        node.callee.type === 'Identifier' &&
+                        node.callee.name === 'require' &&
+                        node[argPropName] && node[argPropName].length === 1) {
 
-                arg = node[argPropName][0];
-                if (arg.type === 'Literal') {
-                    deps.push(arg.value);
+                    arg = node[argPropName][0];
+                    if (arg.type === 'Literal') {
+                        deps.push(arg.value);
+                        if (param) {
+                            params.push(param);
+                        }
+                    }
+                } else if (node.type === 'VariableDeclarator') {
+                    if (node.id && node.id.type === 'Identifier') {
+                        param = node.id.name;
+                    }
+                    return;
+                } else if (node.type === 'AssignmentExpression') {
+                    if (node.left && node.left.type === 'Identifier') {
+                        param = node.left.name;
+                    }
+                    return;
+                } else if (node.type === 'Identifier') {
+                    //Do not clear the parameter name in the current
+                    //declaration or assignment. The identifier is parsed
+                    //between the left and riht parts of the statement.
+                    return;
                 }
+            }
+            // If range or loc options are set, nodes without type occur.
+            if (node.type) {
+                param = null;
             }
         });
     };
@@ -861,6 +923,10 @@ define(['esprima', './lang'], function (esprima, lang) {
             deps = getValidDeps(arg);
             if (!deps) {
                 return;
+            }
+            factory = node[argPropName][1];
+            if (isFnExpression(factory)) {
+                deps.params = getFormalParameters(factory);
             }
 
             return onMatch("require", null, null, deps, node);
@@ -914,6 +980,9 @@ define(['esprima', './lang'], function (esprima, lang) {
 
             if (deps && deps.type === 'ArrayExpression') {
                 deps = getValidDeps(deps);
+                if (isFnExpression(factory)) {
+                    deps.params = getFormalParameters(factory);
+                }
             } else if (isFnExpression(factory)) {
                 //If no deps and a factory function, could be a commonjs sugar
                 //wrapper, scan the function for dependencies.

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -876,16 +876,22 @@ define(['esprima', './lang'], function (esprima, lang) {
                         param = node.left.name;
                     }
                     return;
+                } else if (node.type === 'Property') {
+                    if (node.key && node.key.type === 'Identifier') {
+                        param = node.key.name;
+                    }
+                    return;
                 } else if (node.type === 'Identifier') {
                     //Do not clear the parameter name in the current
                     //declaration or assignment. The identifier is parsed
-                    //between the left and riht parts of the statement.
+                    //between the left and right parts of the statement.
                     return;
                 }
-            }
-            // If range or loc options are set, nodes without type occur.
-            if (node.type) {
-                param = null;
+
+                // If range or loc options are set, nodes without type occur.
+                if (node.type) {
+                    param = null;
+                }
             }
         });
     };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -11,8 +11,6 @@ var define = function(ary, fn) {
  * see: http://github.com/jrburke/requirejs for details
  */
 
-/*global define */
-
 define([ 'esprima', './parse', './lang'],
 function (esprima, parse, lang) {
     'use strict';
@@ -32,7 +30,8 @@ function (esprima, parse, lang) {
     }
 
     transform = {
-        toTransport: function (namespace, moduleName, path, contents, onFound, options) {
+        toTransport: function (namespace, moduleName, path, contents,
+                onFound, options) {
             options = options || {};
 
             var astRoot, contentLines, modLine,
@@ -43,7 +42,8 @@ function (esprima, parse, lang) {
                 applySourceUrl = function (contents) {
                     if (options.useSourceUrl) {
                         contents = 'eval("' + lang.jsEscape(contents) +
-                            '\\n//# sourceURL=' + (path.indexOf('/') === 0 ? '' : '/') +
+                            '\\n//# sourceURL=' +
+                            (path.indexOf('/') === 0 ? '' : '/') +
                             path +
                             '");\n';
                     }
@@ -84,10 +84,12 @@ function (esprima, parse, lang) {
                         init.callee.callee &&
                         init.callee.callee.type === 'Identifier' &&
                         init.callee.callee.name === 'require' &&
-                        init.callee.arguments && init.callee.arguments.length === 1 &&
+                        init.callee.arguments &&
+                        init.callee.arguments.length === 1 &&
                         init.callee.arguments[0].type === 'Literal' &&
                         init.callee.arguments[0].value &&
-                        init.callee.arguments[0].value.indexOf('amdefine') !== -1) {
+                        init.callee.arguments[0].value
+                            .indexOf('amdefine') !== -1) {
                         // the var define = require('amdefine')(module) case,
                         // keep going in that case.
                     } else {
@@ -135,10 +137,10 @@ function (esprima, parse, lang) {
                             needsId = true;
                             depAction = 'skip';
                         } else if (firstArg.type === 'UnaryExpression' &&
-                                   firstArg.operator === '-' &&
-                                   firstArg.argument &&
-                                   firstArg.argument.type === 'Literal' &&
-                                   typeof firstArg.argument.value === 'number') {
+                                firstArg.operator === '-' &&
+                                firstArg.argument &&
+                                firstArg.argument.type === 'Literal' &&
+                                typeof firstArg.argument.value === 'number') {
                             //define('-12345');
                             needsId = true;
                             depAction = 'skip';
@@ -195,9 +197,10 @@ function (esprima, parse, lang) {
                         if (foundAnon) {
                             var logger = options.logger;
                             if (logger && logger.warn) {
-                               logger.warn(path + ' has more than one anonymous ' +
-                                'define. May be a built file from another ' +
-                                'build system like, Ender. Skipping normalization.');
+                               logger.warn(path + ' has more than one ' +
+                                'anonymous define. May be a built file ' +
+                                'from another build system like, Ender. ' +
+                                'Skipping normalization.');
                             }
                             defineInfos = [];
                             return false;
@@ -250,11 +253,12 @@ function (esprima, parse, lang) {
                     contentInsertion = '',
                     depString = '';
 
-                //Do the modifications "backwards", in other words, start with the
-                //one that is farthest down and work up, so that the ranges in the
-                //defineInfos still apply. So that means deps, id, then namespace.
+                //Do the modifications "backwards", in other words, start
+                //with the one that is farthest down and work up, so that
+                //the ranges in the defineInfos still apply. So that means
+                //deps, id, then namespace.
                 if (info.needsId && moduleName) {
-                    contentInsertion += "'" + moduleName + "',";
+                    contentInsertion += '\'' + moduleName + '\',';
                 }
 
                 if (info.depAction === 'scan') {
@@ -262,7 +266,7 @@ function (esprima, parse, lang) {
 
                     if (deps.length) {
                         depString = '[' + deps.map(function (dep) {
-                            return "'" + dep + "'";
+                            return '\'' + dep + '\'';
                         }) + ']';
                     } else {
                         depString = '[]';
@@ -336,7 +340,8 @@ function (esprima, parse, lang) {
                 baseIndent = '',
                 startString = fileContents.substring(0, start),
                 existingConfigString = fileContents.substring(start, end),
-                lineReturn = existingConfigString.indexOf('\r') === -1 ? '\n' : '\r\n',
+                lineReturn = existingConfigString.indexOf('\r') === -1 ?
+                    '\n' : '\r\n',
                 lastReturnIndex = startString.lastIndexOf('\n');
 
             //Get the basic amount of indent for the require config call.
@@ -344,7 +349,8 @@ function (esprima, parse, lang) {
                 lastReturnIndex = 0;
             }
 
-            match = baseIndentRegExp.exec(startString.substring(lastReturnIndex + 1, start));
+            match = baseIndentRegExp.exec(startString.substring(
+                lastReturnIndex + 1, start));
             if (match && match[1]) {
                 baseIndent = match[1];
             }
@@ -364,11 +370,11 @@ function (esprima, parse, lang) {
             outDentRegExp = new RegExp('(' + lineReturn + ')' + indent, 'g');
 
             configString = transform.objectToString(config, {
-                                                    indent: indent,
-                                                    lineReturn: lineReturn,
-                                                    outDentRegExp: outDentRegExp,
-                                                    quote: options && options.quote
-                                                });
+                indent: indent,
+                lineReturn: lineReturn,
+                outDentRegExp: outDentRegExp,
+                quote: options && options.quote
+            });
 
             //Add in the base indenting level.
             configString = applyIndent(configString, baseIndent, lineReturn);
@@ -385,8 +391,10 @@ function (esprima, parse, lang) {
          * @param  {Object} options    options object with the following values:
          *         {String} indent     the indentation to use for each level
          *         {String} lineReturn the type of line return to use
-         *         {outDentRegExp} outDentRegExp the regexp to use to outdent functions
-         *         {String} quote      the quote type to use, ' or ". Optional. Default is "
+         *         {outDentRegExp} outDentRegExp the regexp to use to
+         *                                       outdent functions
+         *         {String} quote      the quote type to use, ' or ".
+         *                             Optional. Default is "
          * @param  {String} totalIndent the total indent to print for this level
          * @return {String}            a string representation of the object.
          */
@@ -433,8 +441,8 @@ function (esprima, parse, lang) {
                 lang.eachProp(obj, function (v, prop) {
                     value += (first ? '': ',' + lineReturn) +
                         nextIndent +
-                        (keyRegExp.test(prop) ? prop : quote + lang.jsEscape(prop) + quote )+
-                        ': ' +
+                        (keyRegExp.test(prop) ? prop : quote +
+                        lang.jsEscape(prop) + quote ) + ': ' +
                         transform.objectToString(v,
                                                  options,
                                                  nextIndent);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "AMD module tracing for build processes.",
   "main": "trace.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha test"
+    "lint": "jshint *.js lib/*.js read/*.js write/*.js test/*.js",
+    "check": "mocha test",
+    "test": "npm run lint && npm run check"
   },
   "repository": {
     "type": "git",
@@ -28,6 +30,7 @@
     "esprima": "^4.0.0"
   },
   "devDependencies": {
+    "jshint": "^2.9.5",
     "mocha": "^2.2.1"
   }
 }

--- a/parse.js
+++ b/parse.js
@@ -57,6 +57,29 @@ var parse = {
       modules: dependencies,
       params: params
     }
+  },
+
+  /**
+   * Finds only CommonJS dependencies, ones that are the form 
+   * require('stringLiteral'). Expects a JavaScript module. The returned
+   * list of dependent modules and their formal parameters match in the
+   * correct code.
+   *
+   * @param  {String} contents String or Object. File contents of a CommonJS
+   * module, or an AST root produced by the `parse` method.
+   * @return {Object} Returns an object with two properties. The property
+   * "modules" is an array of dependent module paths as strings. The
+   * dependencies have not been normalized; they may be relative IDs.
+   * The property "params" is an array of formal parameter names as strings.
+   */
+  findCjsDependencies: function(contents) {
+    var dependencies = privateParse.findCjsDependencies('', contents, {}),
+        params = dependencies.params;
+    delete dependencies.params;
+    return  {
+      modules: dependencies,
+      params: params
+    }
   }
 };
 

--- a/parse.js
+++ b/parse.js
@@ -22,7 +22,7 @@ var parse = {
   /**
    * Walks the AST from the specified (root) node up to its leaves and calls
    * the specified callback function with two arguments - the visited node
-   * and its parent node.
+   * and its parent node. Once the callback returns `false`, traversing stops.
    *
    * @param {Object} node AST root node to start traversing with. Produced
    * by the `parse` method.
@@ -30,6 +30,20 @@ var parse = {
    */
   traverse: function (node, visitor) {
     return privateParse.traverse(node, visitor);
+  },
+
+  /**
+   * Walks the AST from the specified (root) node up to its leaves and calls
+   * the specified callback function with two arguments - the visited node
+   * and its parent node. Once the callback returns `false`, its children
+   * will be skipped and the traversing will continue with its next sibling.
+   *
+   * @param {Object} node AST root node to start traversing with. Produced
+   * by the `parse` method.
+   * @param {Function} visitor Callback receiving nodes with its parents.
+   */
+  traverseBroad: function (node, visitor) {
+    return privateParse.traverseBroad(node, visitor);
   },
 
   /**
@@ -53,7 +67,7 @@ var parse = {
     return  {
       modules: dependencies,
       params: params
-    }
+    };
   },
 
   /**
@@ -76,7 +90,7 @@ var parse = {
     return  {
       modules: dependencies,
       params: params
-    }
+    };
   }
 };
 

--- a/parse.js
+++ b/parse.js
@@ -1,0 +1,63 @@
+'use strict';
+var privateParse = require('./lib/parse');
+
+/**
+ * Functions for parsing and analysing dependencies of AMD modules. Mostly a
+ * wrapper around lib/ modules, but want to try not exposing the libs directly,
+ * and provide a cleaner interface.
+ */
+var parse = {
+  /**
+   * Parses the input JavaScript text and returns a AST of it. Expects a
+   * JavaScript content. The returned object can be used later in other calls,
+   * or to other module analysis.
+   *
+   * @param {String} contents File contents of an AMD module.
+   * @param {Object} options Optional. Options for the `esprima` parser: Only
+   * `range` and `loc` properties are recognized.
+   * @return {Object} Optional. Options for the `esprima` parser: Only `range`
+   * and `loc` properties are recognized.
+   */
+  parse: function (contents, options) {
+    return privateParse.parseFileContents('', contents, options);
+  },
+
+  /**
+   * Walks the AST from the specified (root) node up to its leaves and calls
+   * the specified callback function with two arguments - the visited node
+   * and its parent node.
+   *
+   * @param {Object} node AST root node to start traversing with. Produced
+   * by the `parse` method.
+   * @param {Function} visitor Callback receiving nodes with its parents.
+   */
+  traverse: function (node, visitor) {
+    return privateParse.traverse(node, visitor);
+  },
+
+  /**
+   * Finds all dependencies specified in the AMD module dependency array, or
+   * inside simplified CommonJS wrappers inside the module factory function.
+   * Expects a JavaScript AMD module wrapped in a `requirejs/require/define`
+   * call. The returned list of dependent modules and their formal parameters
+   * match in the correct code.
+   *
+   * @param  {String} contents String or Object. File contents of an AMD
+   * module, or an AST root produced by the `parse` method.
+   * @return {Object} Returns an object with two properties. The property
+   * "modules" is an array of dependent module paths as strings. The
+   * dependencies have not been normalized; they may be relative IDs.
+   * The property "params" is an array of formal parameter names as strings.
+   */
+  findDependencies: function(contents) {
+    var dependencies = privateParse.findDependencies('', contents, {}),
+        params = dependencies.params;
+    delete dependencies.params;
+    return  {
+      modules: dependencies,
+      params: params
+    }
+  }
+};
+
+module.exports = parse;

--- a/parse.js
+++ b/parse.js
@@ -5,23 +5,20 @@ var privateParse = require('./lib/parse');
  * Functions for parsing and analysing dependencies of AMD modules. Mostly a
  * wrapper around lib/ modules, but want to try not exposing the libs directly,
  * and provide a cleaner interface.
+ *
+ * If you want to obtain JavaScript AST, which is used by the methods
+ * below, use a parser producing output according to the ESTree Spec
+ * (https://github.com/estree/estree). For example, Esprima
+ * (https://github.com/jquery/esprima):
+ *
+ * var esprima = require('esprima');
+ *
+ * var astRoot = esprima.parse(fileContents, {
+ *   range: includeIndexBasedRangeLocation,
+ *   loc: includeLineAndColumnBasedLocation
+ * });
  */
 var parse = {
-  /**
-   * Parses the input JavaScript text and returns a AST of it. Expects a
-   * JavaScript content. The returned object can be used later in other calls,
-   * or to other module analysis.
-   *
-   * @param {String} contents File contents of an AMD module.
-   * @param {Object} options Optional. Options for the `esprima` parser: Only
-   * `range` and `loc` properties are recognized.
-   * @return {Object} Optional. Options for the `esprima` parser: Only `range`
-   * and `loc` properties are recognized.
-   */
-  parse: function (contents, options) {
-    return privateParse.parseFileContents('', contents, options);
-  },
-
   /**
    * Walks the AST from the specified (root) node up to its leaves and calls
    * the specified callback function with two arguments - the visited node

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -106,4 +106,27 @@ describe('parse', function() {
       assert.equal(dependencies.params[0], 'a');
     });
   });
+
+  describe('findCjsDependenccies', function() {
+    it('with an CJS module', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/cjs/controller.js'), 'utf8');
+      var dependencies = amodroParse.findCjsDependencies(content);
+      assert.equal(dependencies.modules.length, 1);
+      assert.equal(dependencies.modules[0], './model');
+      assert.equal(dependencies.params.length, 1);
+      assert.equal(dependencies.params[0], 'model');
+    });
+
+    it('with an already parsed content', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/cjs/controller.js'), 'utf8');
+      var astRoot = esprima.parse(content);
+      var dependencies = amodroParse.findCjsDependencies(astRoot);
+      assert.equal(dependencies.modules.length, 1);
+      assert.equal(dependencies.modules[0], './model');
+      assert.equal(dependencies.params.length, 1);
+      assert.equal(dependencies.params[0], 'model');
+    });
+  });
 });

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -51,7 +51,7 @@ describe('parse', function() {
   });
   
   describe('findDependenccies', function() {
-    it('with an AMD module', function() {
+    it('with an AMD main application', function() {
       var content = fs.readFileSync(path.join(__dirname,
               'source/trace/simple/main.js'), 'utf8');
       var dependencies = amodroParse.findDependencies(content);
@@ -61,7 +61,7 @@ describe('parse', function() {
       assert.equal(dependencies.params[0], 'a');
     });
 
-    it('with a CJS module', function() {
+    it('with a CJS main application', function() {
       var content = fs.readFileSync(path.join(__dirname,
               'source/trace/simple/main-cjs.js'), 'utf8');
       var dependencies = amodroParse.findDependencies(content);
@@ -71,6 +71,28 @@ describe('parse', function() {
       assert.equal(dependencies.params.length, 2);
       assert.equal(dependencies.params[0], 'require');
       assert.equal(dependencies.params[1], 'a');
+    });
+
+    it('with an AMD module', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/c.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 1);
+      assert.equal(dependencies.modules[0], 'b');
+      assert.equal(dependencies.params.length, 1);
+      assert.equal(dependencies.params[0], 'b');
+    });
+
+    it('with a CJS module', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/c-cjs.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 2);
+      assert.equal(dependencies.modules[0], 'require');
+      assert.equal(dependencies.modules[1], 'b');
+      assert.equal(dependencies.params.length, 2);
+      assert.equal(dependencies.params[0], 'require');
+      assert.equal(dependencies.params[1], 'b');
     });
 
     it('with an already parsed content', function() {

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -1,0 +1,87 @@
+/*global describe, it */
+'use strict';
+
+var amodroParse = require('../parse'),
+    assert = require('assert'),
+    esprima = require('esprima'),
+    fs = require('fs'),
+    path = require('path');
+
+describe('parse', function() {
+  describe('parse', function() {
+    var content;
+    
+    before(function() {
+      content = fs.readFileSync(path.join(__dirname,
+          'source/trace/simple/main.js'), 'utf8');
+    });
+  
+    it('without parser options', function() {
+      var astRoot = amodroParse.parse(content);
+      assert.ok(astRoot);
+    });
+
+    it('with parser options', function() {
+      var astRoot = amodroParse.parse(content, {
+        range: true,
+        loc: true
+      });
+      assert.ok(astRoot);
+      assert.ok(astRoot.range);
+      assert.ok(astRoot.loc);
+    });
+  });
+  
+  describe('traverse', function() {
+    it('visits a known node', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/main.js'), 'utf8');
+      var astRoot = esprima.parse(content);
+      var identifierNode, callNode;
+      amodroParse.traverse(astRoot, function (node, parent) {
+        if (node && node.type === 'Identifier' &&
+            node.name === 'require') {
+              identifierNode = node;
+              callNode = parent;
+            }
+      });
+      assert.ok(identifierNode);
+      assert.ok(callNode);
+    });
+  });
+  
+  describe('findDependenccies', function() {
+    it('with an AMD module', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/main.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 1);
+      assert.equal(dependencies.modules[0], 'a');
+      assert.equal(dependencies.params.length, 1);
+      assert.equal(dependencies.params[0], 'a');
+    });
+
+    it('with a CJS module', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/main-cjs.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 2);
+      assert.equal(dependencies.modules[0], 'require');
+      assert.equal(dependencies.modules[1], 'a');
+      assert.equal(dependencies.params.length, 2);
+      assert.equal(dependencies.params[0], 'require');
+      assert.equal(dependencies.params[1], 'a');
+    });
+
+    it('with an already parsed content', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/main.js'), 'utf8');
+      var astRoot = esprima.parse(content);
+      var dependencies = amodroParse.findDependencies(astRoot);
+      assert.equal(dependencies.modules.length, 1);
+      assert.equal(dependencies.modules[0], 'a');
+      assert.equal(dependencies.params.length, 1);
+      assert.equal(dependencies.params[0], 'a');
+    });
+  });
+});

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -155,6 +155,38 @@ describe('parse', function() {
       assert.equal(dependencies.params.length, 1);
       assert.equal(dependencies.params[0], 'a');
     });
+
+    it('with a module exporting an object literal', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/module-object-only.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 0);
+      assert.equal(dependencies.params.length, 0);
+    });
+
+    it('with a module with "explicitly" empty dependencies', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/module-empty-deps.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 0);
+      assert.equal(dependencies.params.length, 0);
+    });
+
+    it('with an application passing an object literal', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/app-object-only.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 0);
+      assert.equal(dependencies.params.length, 0);
+    });
+
+    it('withn an application with "explicitly" empty dependencies', function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/simple/app-empty-deps.js'), 'utf8');
+      var dependencies = amodroParse.findDependencies(content);
+      assert.equal(dependencies.modules.length, 0);
+      assert.equal(dependencies.params.length, 0);
+    });
   });
 
   describe('findCjsDependenccies', function() {

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -8,30 +8,6 @@ var amodroParse = require('../parse'),
     path = require('path');
 
 describe('parse', function() {
-  describe('parse', function() {
-    var content;
-    
-    before(function() {
-      content = fs.readFileSync(path.join(__dirname,
-          'source/trace/simple/main.js'), 'utf8');
-    });
-  
-    it('without parser options', function() {
-      var astRoot = amodroParse.parse(content);
-      assert.ok(astRoot);
-    });
-
-    it('with parser options', function() {
-      var astRoot = amodroParse.parse(content, {
-        range: true,
-        loc: true
-      });
-      assert.ok(astRoot);
-      assert.ok(astRoot.range);
-      assert.ok(astRoot.loc);
-    });
-  });
-  
   describe('traverse', function() {
     it('visits a known node', function() {
       var content = fs.readFileSync(path.join(__dirname,
@@ -49,7 +25,7 @@ describe('parse', function() {
       assert.ok(callNode);
     });
   });
-  
+
   describe('findDependenccies', function() {
     it('with an AMD main application', function() {
       var content = fs.readFileSync(path.join(__dirname,

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -1,4 +1,4 @@
-/*global describe, it */
+/*global describe, before, it */
 'use strict';
 
 var amodroParse = require('../parse'),
@@ -9,12 +9,16 @@ var amodroParse = require('../parse'),
 
 describe('parse', function() {
   describe('traverse', function() {
-    it('visits a known node', function() {
+    before(function() {
       var content = fs.readFileSync(path.join(__dirname,
               'source/trace/simple/main.js'), 'utf8');
-      var astRoot = esprima.parse(content);
-      var identifierNode, callNode;
-      amodroParse.traverse(astRoot, function (node, parent) {
+      this.astRoot = esprima.parse(content);
+    });
+
+    it('visits a known node', function() {
+      var identifierNode, callNode, lastNode;
+      amodroParse.traverse(this.astRoot, function (node, parent) {
+        lastNode = node;
         if (node && node.type === 'Identifier' &&
             node.name === 'require') {
               identifierNode = node;
@@ -23,6 +27,76 @@ describe('parse', function() {
       });
       assert.ok(identifierNode);
       assert.ok(callNode);
+      assert.ok(identifierNode !== lastNode);
+    });
+
+    it('stops traversing, once the visitor returns `true`', function() {
+      var identifierNode, lastNode;
+      amodroParse.traverse(this.astRoot, function (node) {
+        lastNode = node;
+        if (node && node.type === 'Identifier' &&
+            node.name === 'require') {
+              identifierNode = node;
+              return false;
+            }
+      });
+      assert.ok(identifierNode);
+      assert.ok(identifierNode === lastNode);
+    });
+  });
+
+  describe('traverseBroad', function() {
+    before(function() {
+      var content = fs.readFileSync(path.join(__dirname,
+              'source/trace/nested/a.js'), 'utf8');
+      this.astRoot = esprima.parse(content);
+    });
+
+    it('visits known nodes', function() {
+      var defineNode, requireNode, argumentNode, returnNode;
+      amodroParse.traverseBroad(this.astRoot, function (node, parent) {
+        if (node && node.type === 'ExpressionStatement' &&
+            node.expression && node.expression.type === 'CallExpression' &&
+            node.expression.callee &&
+            node.expression.callee.type === 'Identifier' &&
+            node.expression.callee.name === 'require') {
+              requireNode = node;
+              defineNode = parent;
+            }
+        if (node && node.type === 'Literal' && node.value === 'e') {
+              argumentNode = node;
+            }
+        if (node && node.type === 'ReturnStatement') {
+              returnNode = node;
+            }
+      });
+      assert.ok(defineNode);
+      assert.ok(requireNode);
+      assert.ok(argumentNode);
+      assert.ok(returnNode);
+    });
+
+    it('skips traversing children, if the visitor returns `true`', function() {
+      var requireNode, argumentNode, returnNode;
+      amodroParse.traverseBroad(this.astRoot, function (node, parent) {
+        if (node && node.type === 'ExpressionStatement' &&
+            node.expression && node.expression.type === 'CallExpression' &&
+            node.expression.callee &&
+            node.expression.callee.type === 'Identifier' &&
+            node.expression.callee.name === 'require') {
+              requireNode = node;
+              return false;
+            }
+        if (node && node.type === 'Literal' && node.value === 'e') {
+              argumentNode = node;
+            }
+        if (node && node.type === 'ReturnStatement') {
+              returnNode = node;
+            }
+      });
+      assert.ok(requireNode);
+      assert.ok(!argumentNode);
+      assert.ok(returnNode);
     });
   });
 

--- a/test/source/trace/simple/app-empty-deps.js
+++ b/test/source/trace/simple/app-empty-deps.js
@@ -1,0 +1,3 @@
+'use strict';
+require([], function () {
+});

--- a/test/source/trace/simple/app-object-only.js
+++ b/test/source/trace/simple/app-object-only.js
@@ -1,0 +1,4 @@
+'use strict';
+require({
+  name: 'test'
+});

--- a/test/source/trace/simple/c-cjs.js
+++ b/test/source/trace/simple/c-cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+define(function(require) {
+  var b = require('b');
+  return {};
+});

--- a/test/source/trace/simple/c.js
+++ b/test/source/trace/simple/c.js
@@ -1,0 +1,4 @@
+'use strict';
+define(['b'], function(b) {
+  return {};
+});

--- a/test/source/trace/simple/main-cjs.js
+++ b/test/source/trace/simple/main-cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+define(function(require) {
+  var a = require('a');
+  console.log(a);
+});

--- a/test/source/trace/simple/main-cjs.js
+++ b/test/source/trace/simple/main-cjs.js
@@ -1,5 +1,5 @@
 'use strict';
-define(function(require) {
+require(function(require) {
   var a = require('a');
   console.log(a);
 });

--- a/test/source/trace/simple/module-empty-deps.js
+++ b/test/source/trace/simple/module-empty-deps.js
@@ -1,0 +1,3 @@
+'use strict';
+define([], function () {
+});

--- a/test/source/trace/simple/module-object-only.js
+++ b/test/source/trace/simple/module-object-only.js
@@ -1,0 +1,4 @@
+'use strict';
+define({
+  name: 'test'
+});

--- a/test/trace-test.js
+++ b/test/trace-test.js
@@ -210,7 +210,8 @@ describe('trace', function() {
 
   it('trace-cache-1', function(done) {
 
-    var traceCachePath = path.join(baseDir, 'trace-cache-1', 'already-traced.json');
+    var traceCachePath = path.join(baseDir, 'trace-cache-1',
+          'already-traced.json');
     var traceCache = JSON.parse(readFile(traceCachePath));
 
     runTrace(done, 'trace-cache-1', {
@@ -227,7 +228,8 @@ describe('trace', function() {
 
   it('trace-cache-plugin', function(done) {
 
-    var traceCachePath = path.join(baseDir, 'trace-cache-plugin', 'already-traced.json');
+    var traceCachePath = path.join(baseDir, 'trace-cache-plugin',
+          'already-traced.json');
     var traceCache = JSON.parse(readFile(traceCachePath));
 
     runTrace(done, 'trace-cache-plugin', {


### PR DESCRIPTION
Usage of the undefined "key" identifier in "traverseBroad" showed, that it is worth to run it regularly. See https://github.com/amodrojs/amodro-trace/blob/1.0.2/lib/parse.js#L68.

This is based on the code proposed with #14, which includes also the fix for the bug above; not on the current master.